### PR TITLE
Fix httpx Response.json() usage in async methods

### DIFF
--- a/src/utils/espn_api_client.py
+++ b/src/utils/espn_api_client.py
@@ -344,8 +344,8 @@ class ESPNApiClient:
                     # Mark as successful
                     success = True
 
-                    # Parse JSON response - must await the json() coroutine
-                    json_data = await response.json()
+                    # Parse JSON response
+                    json_data = response.json()
                     return dict(json_data)
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code

--- a/tests/utils/test_espn_api_client.py
+++ b/tests/utils/test_espn_api_client.py
@@ -564,8 +564,8 @@ class TestESPNApiClient:
         )
         client = ESPNApiClient(config)
 
-        # Fix the response.json() coroutine issue
-        mock_httpx_async_client.get.return_value.json = AsyncMock(
+        # Fix the response.json() coroutine issue - now a regular MagicMock
+        mock_httpx_async_client.get.return_value.json = MagicMock(
             return_value={"events": [{"id": "test"}]}
         )
 


### PR DESCRIPTION
## Issue
When running scoreboard ingestion, we encountered an error with httpx Response.json() method:
`TypeError: object dict can't be used in 'await' expression`

## Fix
- Removed the await keyword when calling response.json() in _request_async()
- Updated the tests to use MagicMock instead of AsyncMock for response.json()

This fix allows the async scoreboard ingestion to work properly with httpx's synchronous json() method. 